### PR TITLE
Minor changes around users module

### DIFF
--- a/controllers/admin/users.rb
+++ b/controllers/admin/users.rb
@@ -15,7 +15,7 @@ get '/admin/users/?' do
   if(@usr_bus.nil? or @usr_bus=="")
     @users=[]
   else
-    @users=User.filter(Sequel.like(:name, "%#{@usr_bus}%")).order(:name)
+    @users=User.filter(Sequel.ilike(:name, "%#{@usr_bus}%")).order(:name)
   end
   #log.info(@personas.all)  
   @roles=Role.order()

--- a/controllers/user.rb
+++ b/controllers/user.rb
@@ -27,7 +27,7 @@ get '/user/:user_id' do |user_id|
 
   @rss=@usuario.systematic_reviews.where(:active=>true)
 
-  @select_role=get_xeditable_select(Role.inject({}) {|ac,v| ac[v[:id]]=v[:id];ac},'/user/edit/role_id','select_role')
+  @select_role=get_xeditable_select(Hash[Role.map{ |r| [r[:id], r[:id]] }],'/user/edit/role_id','select_role')
   @select_role.active=false if(!auth_to("user_admin") or user_id.to_i==session['user_id'])
 
   @select_active_user=get_xeditable_select_bool('/user/edit/active','select_active')

--- a/controllers/user.rb
+++ b/controllers/user.rb
@@ -27,10 +27,10 @@ get '/user/:user_id' do |user_id|
 
   @rss=@usuario.systematic_reviews.where(:active=>true)
 
-  @select_role=get_xeditable_select(Role.inject({}) {|ac,v| ac[v[:id]]=v[:id];ac},'/user/edit/rol_id','select_role')
+  @select_role=get_xeditable_select(Role.inject({}) {|ac,v| ac[v[:id]]=v[:id];ac},'/user/edit/role_id','select_role')
   @select_role.active=false if(!auth_to("user_admin") or user_id.to_i==session['user_id'])
 
-  @select_active_user=get_xeditable_select_bool('/user/edit/activa','select_active')
+  @select_active_user=get_xeditable_select_bool('/user/edit/active','select_active')
   @select_active_user.active=false if(!auth_to("user_admin") or user_id.to_i==session['user_id'])
 
   @select_language=get_xeditable_select(available_locales_hash, '/user/edit/language','select_language')

--- a/db/migrations/16_indeces_to_users.rb
+++ b/db/migrations/16_indeces_to_users.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:users) do
+      add_index :login, unique: true
+    end
+  end
+end

--- a/lib/sinatra/xeditable_select.rb
+++ b/lib/sinatra/xeditable_select.rb
@@ -58,7 +58,8 @@ module Sinatra
       end
 
       def html(id, value)
-        value_value = value.nil? ? nil_value.to_s : value.to_s
+        value_value = (value && 1 || 0) if [TrueClass, FalseClass].include?(value.class)
+        value_value ||= value.nil? ? nil_value.to_s : value.to_s
         value_text = value.nil? ? values[nil_value.to_s] : values[value.to_s]
         return value_text if !active
         "<a href='#' class='#{html_class}' id='select-#{html_class}-#{id}' data-value='#{value_value}' data-pk='#{id}'>#{value_text}</a>"
@@ -74,8 +75,8 @@ module Sinatra
       end
 
       def get_xeditable_select_bool(url, html_class)
-        values = {0 => ::I18n.t("No"),
-                  1 => ::I18n.t("Yes")
+        values = {'0' => ::I18n.t("No"),
+                  '1' => ::I18n.t("Yes")
         }
         Select.new(values, url, html_class)
       end

--- a/model/user.rb
+++ b/model/user.rb
@@ -33,13 +33,13 @@ class User < Sequel::Model
   end
 
   def systematic_reviews_id
-
     $db["SELECT id FROM systematic_reviews rs INNER JOIN groups_users gu ON rs.group_id=gu.group_id WHERE user_id=?", self[:id]].select_map(:id)
   end
 
   def systematic_reviews
     SystematicReview.where(:id => systematic_reviews_id)
   end
+
   def accesible_users
     User.where(:id=>$db["SELECT DISTINCT(user_id) FROM groups_users WHERE group_id IN (SELECT group_id FROM groups_users WHERE user_id=?)", self[:id]].map(:user_id))
   end
@@ -51,8 +51,6 @@ class User < Sequel::Model
   def correct_password?(test_password)
     self.password == Digest::SHA1.hexdigest(test_password)
   end
-
-
 
   def self.create_new_user(language='en')
     ultimo_usuario=$db["SELECT max(id) as max_id from users"].get(:max_id).to_i

--- a/views/users.haml
+++ b/views/users.haml
@@ -31,9 +31,9 @@
             %td
               %input{:type=>:text, :user=>10, :name=>"usuario[#{per[:id]}][login]", :value=>per[:login]}
             %td
-              %input{:type=>:checkbox, :name=>"usuario[#{per[:id]}][activa]", :checked=>per[:active]}
+              %input{:type=>:checkbox, :name=>"usuario[#{per[:id]}][active]", :checked=>per[:active]}
             %td
-              %select{:name=>"usuario[#{per[:id]}][rol_id]"}
+              %select{:name=>"usuario[#{per[:id]}][role_id]"}
                 -@roles.each do |rol|
                   %option{:value=>rol[:id], :selected=>(rol[:id]==per[:rol_id])}=rol[:id]
     %input.btn.btn-default{:type=>"submit",:name=>t(:Update)}

--- a/views/users.haml
+++ b/views/users.haml
@@ -34,8 +34,8 @@
               %input{:type=>:checkbox, :name=>"usuario[#{per[:id]}][active]", :checked=>per[:active]}
             %td
               %select{:name=>"usuario[#{per[:id]}][role_id]"}
-                -@roles.each do |rol|
-                  %option{:value=>rol[:id], :selected=>(rol[:id]==per[:rol_id])}=rol[:id]
+                -@roles.each do |role|
+                  %option{:value=>role[:id], :selected=>(role[:id]==per[:role_id])}=role[:id]
     %input.btn.btn-default{:type=>"submit",:name=>t(:Update)}
 - else
   .alert.alert-warning=t(:No_user_found)


### PR DESCRIPTION
Addresses the following:

1. Adds unique constraint on users `login` to prevent duplicates on parallel user create request. Getting max_id is not threadsafe.
2. Made users search case insensitive.
3. Fixed issues around user's updatation of `role_id` and `active` status. The test cases around that were correct, but origination of request in buhos addressed them with translated words(`rol_id` and `activa`) which didn't match model's attributes.
4. xeditable bool didn't use to highlight the active option value by default. It is now fixed.